### PR TITLE
Set default voice for 11Labs and add better setup instructions to README

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,17 @@
-OPENAI_API_KEY=""
-DEEPGRAM_API_KEY="YOUR-API-KEY"
-XI_API_KEY="YOUR-API-KEY"
+# Your ngrok or server URL
+# E.g. 123.ngrok.io or myserver.fly.dev
+SERVER="yourserverdomain.com"
+
+# Service API Keys
+OPENAI_API_KEY="sk-XXXXXX"
+DEEPGRAM_API_KEY="YOUR-DEEPGRAM-API-KEY"
+XI_API_KEY="YOUR-ELEVEN-LABS-API-KEY"
 # Available models at a signed GET request to /v1/models
 XI_MODEL_ID="eleven_turbo_v2"
-VOICE_ID="YOUR-VOICE-ID"
-SERVER="yourdomain.ngrok.io"
+
+# See https://api.elevenlabs.io/v1/voices
+# for a list of all available voices
+VOICE_ID="21m00Tcm4TlvDq8ikWAM"
 
 # Configure your Twilio credentials if you want
 # to make test calls using '$ npm test'.
@@ -12,5 +19,3 @@ TWILIO_ACCOUNT_SID="YOUR-ACCOUNT-SID"
 TWILIO_AUTH_TOKEN="YOUR-AUTH-TOKEN"
 FROM_NUMBER='+12223334444'
 TO_NUMBER='+13334445555'
-OPENAI_API_KEY="YOUR-API-KEY"
-WELCOME_MESSAGE="This call may be recorded... Hi there, I'm a personal assistant that you can chat with on the phone. Ask me any question and I'll do my best to answer!"

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Call GPT: Generative AI Phone Calling
 
-Generative AI is producing a bunch of fun new models for us devs to poke at. Did you know you can use these over the phone?
+Wouldn't it be neat if you could build an app that allowed you to chat with ChatGPT on the phone?
 
 Twilio gives you a superpower called [Media Streams](https://twilio.com/media-streams). Media Streams provides a Websocket connection to both sides of a phone call. You can get audio streamed to you, process it, and send audio back.
 
-This repo serves as a demo exploring three models:
+This app serves as a demo exploring three services:
 - [Deepgram](https://deepgram.com/) for Speech to Text
 - [elevenlabs](https://elevenlabs.io) for Text to Speech
 - [OpenAI](https://openai.com) for GPT prompt completion
@@ -12,42 +12,85 @@ This repo serves as a demo exploring three models:
 These service combine to create a voice application that is remarkably better at transcribing, understanding, and speaking than traditional IVR systems.
 
 Features:
-- Returns responses with low latency, typically 1 second by utilizing streaming.
-- Allows the user to interrupt the GPT assistant and ask a different question.
-- Maintains chat history with GPT.
+- 🏁 Returns responses with low latency, typically 1 second by utilizing streaming.
+- ❗️ Allows the user to interrupt the GPT assistant and ask a different question.
+- 📔 Maintains chat history with GPT.
+- 🛠️ Allows the GPT to call external tools.
 
 ## Setting up for Development
-Sign up for Deepgram, ElevenLabs, and OpenAI. You'll need an API key for each service.
 
-Use [ngrok](https://ngrok.com) to tunnel and then expose port `3000`
+### Prerequisites
+Sign up for the following services and get an API key for each:
+- [Deepgram](https://console.deepgram.com/signup)
+- [OpenAI](https://platform.openai.com/signup)
+- [ElevenLabs](https://elevenlabs.io/sign-up)
+
+With ElevenLabs, you'll have the option of using an existing voice or creating a new one. The app is configured to use the "Rachel" voice by default, but you can find a list of all available voice IDs [here](https://api.elevenlabs.io/v1/voices).
+
+If you're hosting the app locally, we also recommend using a tunneling service like [ngrok](https://ngrok.com) so that Twilio can forward audio to your app.
+
+
+### 1. Start Ngrok
+Start an [ngrok](https://ngrok.com) tunnel for port `3000`:
 
 ```bash
 ngrok http 3000
 ```
+Ngrok will give you a unique URL, like `abc123.ngrok.io`. Copy the URL without http:// or https://. You'll need this URL in the next step.
 
-Copy `.env.example` to `.env` and add all API keys.
+### 2. Configure Environment Variables
+Copy `.env.example` to `.env` and configure the following environment variables:
 
-Set `SERVER` to your tunneled ngrok URL
+```bash
+# Your ngrok or server URL
+# E.g. 123.ngrok.io or myserver.fly.dev
+SERVER="yourserverdomain.com"
 
+# Service API Keys
+OPENAI_API_KEY="sk-XXXXXX"
+DEEPGRAM_API_KEY="YOUR-DEEPGRAM-API-KEY"
+XI_API_KEY="YOUR-ELEVEN-LABS-API-KEY"
+# Available models at a signed GET request to /v1/models
+XI_MODEL_ID="eleven_turbo_v2"
+
+# Uses "Rachel" voice by default
+# See https://api.elevenlabs.io/v1/voices
+# or visit https://elevenlabs.io/voice-library
+# for a list of all available voices
+VOICE_ID="21m00Tcm4TlvDq8ikWAM"
+
+# Configure your Twilio credentials if you want
+# to make test calls using '$ npm test'.
+TWILIO_ACCOUNT_SID="YOUR-ACCOUNT-SID"
+TWILIO_AUTH_TOKEN="YOUR-AUTH-TOKEN"
+FROM_NUMBER='+12223334444'
+TO_NUMBER='+13334445555'
+```
+
+### 3. Install Dependencies with NPM
 Install the necessary packages:
 
 ```bash
 npm install
 ```
 
-Start the web server:
-
+### 4. Start Your Server in Development Mode
+Run the following command:
 ```bash
 npm run dev
 ```
+This will start your app using `nodemon` so that any changes to your code automatically refreshes and restarts the server.
 
-Wire up your Twilio number using the console or CLI
+### 5. Configure an Incoming Phone Number
+
+Connect a phone number using the [Twilio Console](https://console.twilio.com/us1/develop/phone-numbers/manage/incoming).
+
+You can also use the Twilio CLI:
 
 ```bash
 twilio phone-numbers:update +1[your-twilio-number] --voice-url=https://your-server.ngrok.io/incoming
 ```
-
-There is a [Stream](https://www.twilio.com/docs/voice/twiml/stream) TwiML verb that will connect a stream to your websocket server.
+This configuration tells Twilio to send incoming call audio to your app when someone calls your number. The app responds to the incoming call webhook with a [Stream](https://www.twilio.com/docs/voice/twiml/stream) TwiML verb that will connect an audio media stream to your websocket server.
 
 ## Application Workflow
 CallGPT coordinates the data flow between multiple different services including Deepgram, OpenAI, ElevenLabs, and Twilio Media Streams:
@@ -57,11 +100,11 @@ CallGPT coordinates the data flow between multiple different services including 
 ## Modifying the ChatGPT Context & Prompt
 Within `gpt-service.js` you'll find the settings for the GPT's initial context and prompt. For example:
 
-```
+```javascript
 this.userContext = [
-      { "role": "system", "content": "You are an outbound sales representative selling Apple Airpods. You have a youthful and cheery personality. Keep your responses as brief as possible but make every attempt to keep the caller on the phone without being rude. Don't ask more than 1 question at a time. Don't make assumptions about what values to plug into functions. Ask for clarification if a user request is ambiguous. Speak out all prices to include the currency. Please help them decide between the airpods, airpods pro and airpods max by asking questions like 'Do you prefer headphones that go in your ear or over the ear?'. If they are trying to choose between the airpods and airpods pro try asking them if they need noise canceling. Once you know which model they would like ask them how many they would like to purchase and try to get them to place an order. Add a '•' symbol every 5 to 10 words at natural pauses where your response can be split for text to speech." },
-      { "role": "assistant", "content": "Hello! I understand you're looking for a pair of AirPods, is that correct?" },
-    ],
+  { "role": "system", "content": "You are an outbound sales representative selling Apple Airpods. You have a youthful and cheery personality. Keep your responses as brief as possible but make every attempt to keep the caller on the phone without being rude. Don't ask more than 1 question at a time. Don't make assumptions about what values to plug into functions. Ask for clarification if a user request is ambiguous. Speak out all prices to include the currency. Please help them decide between the airpods, airpods pro and airpods max by asking questions like 'Do you prefer headphones that go in your ear or over the ear?'. If they are trying to choose between the airpods and airpods pro try asking them if they need noise canceling. Once you know which model they would like ask them how many they would like to purchase and try to get them to place an order. Add a '•' symbol every 5 to 10 words at natural pauses where your response can be split for text to speech." },
+  { "role": "assistant", "content": "Hello! I understand you're looking for a pair of AirPods, is that correct?" },
+],
 ```
 ### About the `system` Attribute
 The `system` attribute is background information for the GPT. As you build your use-case, play around with modifying the context. A good starting point would be to imagine training a new employee on their first day and giving them the basics of how to help a customer.
@@ -80,12 +123,57 @@ These context items help shape a GPT so that it will act more naturally in a pho
 The `•` symbol context in particular is helpful for the app to be able to break sentences into natural chunks. This speeds up text-to-speech processing so that users hear audio faster.
 
 ### About the `content` Attribute
-This attribute is relatively simple, it is your default conversations starter for the GPT. However, you could consider making it more complex and customized based on personalized user data.
+This attribute is your default conversations starter for the GPT. However, you could consider making it more complex and customized based on personalized user data.
 
 In this case, our bot will start off by saying, "Hello! I understand you're looking for a pair of AirPods, is that correct?"
 
+## Using Function Calls with GPT
+You can use function calls to interact with external APIs and data sources. For example, your GPT could check live inventory, check an item's price, or place an order.
 
-## Adding Custom Function Calls
+### How Function Calling Works
+Function calling is handled within the `gpt-service.js` file in the following sequence:
+
+1. `gpt-service` loads `function-manifest.js` and requires (imports) all functions defined there from the `functions` directory. Our app will call these functions later when GPT gives us a function name and parameters.
+```javascript
+tools.forEach((tool) => {
+  const functionName = tool.function.name;
+  availableFunctions[functionName] = require(`../functions/${functionName}`);
+});
+```
+
+2. When we call GPT for completions, we also pass in the same `function-manifest` JSON as the tools parameter. This allows the GPT to "know" what functions are available:
+
+```javascript
+const stream = await this.openai.chat.completions.create({
+  model: 'gpt-4',
+  messages: this.userContext,
+  tools, // <-- function-manifest definition
+  stream: true,
+});
+```
+3. When the GPT responds, it will send us a stream of chunks for the text completion. The GPT will tell us whether each text chunk is something to say to the user, or if it's a tool call that our app needs to execute.  This is indicated by the `deltas.tool_calls` key:
+```javascript
+if (deltas.tool_calls) {
+  // handle function calling
+}
+```
+4. Once we have gathered all of the stream chunks about the tool call, our application can run the actual function code that we imported during the first step. The function name and parameters are provided by GPT:
+```javascript
+const functionToCall = availableFunctions[functionName];
+const functionResponse = functionToCall(functionArgs);
+```
+5. As the final step, we add the function response data into the conversation context like this:
+
+```javascript
+this.userContext.push({
+  role: 'function',
+  name: functionName,
+  content: functionResponse,
+});
+```
+We then ask the GPT to generate another completion including what it knows from the function call. This allows the GPT to respond to the user with details gathered from the external data source.
+
+### Adding Custom Function Calls
 You can have your GPT call external data sources by adding functions to the `/functions` directory. Follow these steps:
 
 1. Create a function (e.g. `checkInventory.js` in `/functions`)
@@ -129,7 +217,7 @@ Example function manifest entry:
 ### Receiving Function Arguments
 When ChatGPT calls a function, it will provide an object with multiple attributes as a single argument. The parameters included in the object are based on the definition in your `function-manifest.js` file.
 
-In the `checkInventory` example above, `model` is a required argument, so the data passed to the function will be an object like this:
+In the `checkInventory` example above, `model` is a required argument, so the data passed to the function will be a single object like this:
 
 ```javascript
 {


### PR DESCRIPTION
This PR intends to make the setup process easier based on user feedback and questions. It includes the following changes:

- Adds a default voice in the .env file with better instructions for picking a new one
- Adds more details about configuring the Twilio number and server URL.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
