### PR TITLE
Fix bug in gpt-service.js that happens in function calls

### DIFF
--- a/services/gpt-service.js
+++ b/services/gpt-service.js
@@ -108,7 +108,7 @@ class GptService extends EventEmitter {
         let functionResponse = await functionToCall(validatedArgs);
 
         // Step 4: send the info on the function call and function response to GPT
-        this.updateUserContext('function', functionName, functionResponse);
+        this.updateUserContext(functionName, 'function', functionResponse);
         
         // call the completion function again but pass in the function response to have OpenAI generate a new assistant response
         await this.completion(functionResponse, interactionCount, 'function', functionName);


### PR DESCRIPTION
The order of parameters was wrong, causing OpenAI API to give an error because the function name was being passed instead of the role. Simply reordering the parameters would fix this issue (currently only happens in the `transferCall` function)

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
