### PR TITLE
Replace Eleven Labs with Deepgram TTS as default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,13 +5,9 @@ SERVER=
 # Service API Keys
 OPENAI_API_KEY=
 DEEPGRAM_API_KEY=
-XI_API_KEY=
-# Available models at a signed GET request to /v1/models
-XI_MODEL_ID=eleven_turbo_v2
 
-# See https://api.elevenlabs.io/v1/voices
-# for a list of all available voices
-VOICE_ID=21m00Tcm4TlvDq8ikWAM
+# Deepgram voice model, see more options here: https://developers.deepgram.com/docs/tts-models
+VOICE_MODEL=aura-asteria-en
 
 # Optional: Configure your Twilio credentials if you want
 # to make test calls using '$ npm run outbound'.

--- a/README.md
+++ b/README.md
@@ -245,6 +245,41 @@ The `scripts` directory contains two files that allow you to place test calls:
 - `npm run inbound` will place an automated call from a Twilio number to your app and speak a script. You can adjust this to your use-case, e.g. as an automated test.
 - `npm run outbound` will place an outbound call that connects to your app. This can be useful if you want the app to call your phone so that you can manually test it.
 
+## Using Eleven Labs for Text to Speech
+Replace the Deepgram API call and array transformation in tts-service.js with the following call to Eleven Labs. Note that sometimes Eleven Labs will hit a rate limit (especially on the free trial) and return 400 errors with no audio (or a clicking sound).
+
+```
+try {
+  const response = await fetch(
+    `https://api.elevenlabs.io/v1/text-to-speech/21m00Tcm4TlvDq8ikWAM/stream?output_format=ulaw_8000&optimize_streaming_latency=3`,
+    {
+      method: 'POST',
+      headers: {
+        'xi-api-key': process.env.XI_API_KEY,
+        'Content-Type': 'application/json',
+        accept: 'audio/wav',
+      },
+      body: JSON.stringify({
+        model_id: process.env.XI_MODEL_ID,
+        text: partialResponse,
+      }),
+    }
+  );
+  
+  if (response.status === 200) {
+    const audioArrayBuffer = await response.arrayBuffer();
+    this.emit('speech', partialResponseIndex, Buffer.from(audioArrayBuffer).toString('base64'), partialResponse, interactionCount);
+  } else {
+    console.log('Eleven Labs Error:');
+    console.log(response);
+  }
+} catch (err) {
+  console.error('Error occurred in XI LabsTextToSpeech service');
+  console.error(err);
+}
+```
+
+
 ## Testing with Jest
 Repeatedly calling the app can be a time consuming way to test your tool function calls. This project contains example unit tests that can help you test your functions without relying on the GPT to call them.
 

--- a/services/tts-service.js
+++ b/services/tts-service.js
@@ -1,12 +1,10 @@
+require('dotenv').config();
 const EventEmitter = require('events');
-const { Buffer } = require('node:buffer');
 const fetch = require('node-fetch');
 
 class TextToSpeechService extends EventEmitter {
-  constructor(config) {
+  constructor() {
     super();
-    this.config = config;
-    this.config.voiceId ||= process.env.VOICE_ID;
     this.nextExpectedIndex = 0;
     this.speechBuffer = {};
   }
@@ -17,25 +15,33 @@ class TextToSpeechService extends EventEmitter {
     if (!partialResponse) { return; }
 
     try {
-      const outputFormat = 'ulaw_8000';
       const response = await fetch(
-        `https://api.elevenlabs.io/v1/text-to-speech/${this.config.voiceId}/stream?output_format=${outputFormat}&optimize_streaming_latency=3`,
+        `https://api.deepgram.com/v1/speak?model=${process.env.VOICE_MODEL}&encoding=mulaw&sample_rate=8000&container=none`,
         {
           method: 'POST',
           headers: {
-            'xi-api-key': process.env.XI_API_KEY,
+            'Authorization': `Token ${process.env.DEEPGRAM_API_KEY}`,
             'Content-Type': 'application/json',
-            accept: 'audio/wav',
           },
-          // TODO: Pull more config? https://docs.elevenlabs.io/api-reference/text-to-speech-stream
           body: JSON.stringify({
-            model_id: process.env.XI_MODEL_ID,
             text: partialResponse,
           }),
         }
       );
-      const audioArrayBuffer = await response.arrayBuffer();
-      this.emit('speech', partialResponseIndex, Buffer.from(audioArrayBuffer).toString('base64'), partialResponse, interactionCount);
+
+      if (response.status === 200) {
+        try {
+          const blob = await response.blob();
+          const audioArrayBuffer = await blob.arrayBuffer();
+          const base64String = btoa(String.fromCharCode(...new Uint8Array(audioArrayBuffer)));
+          this.emit('speech', partialResponseIndex, base64String, partialResponse, interactionCount);
+        } catch (err) {
+          console.log(err);
+        }
+      } else {
+        console.log('Deepgram TTS error:');
+        console.log(response);
+      }
     } catch (err) {
       console.error('Error occurred in TextToSpeech service');
       console.error(err);


### PR DESCRIPTION
Closes #27

This PR replaces Eleven Labs as the default speech provider for the project. The Eleven Labs source code remains in the README for use.

There were two primary reasons I wanted to switch to using Deepgram:
- Fewer accounts to manage for initial app setup.
- Eleven Labs had an odd behavior of silently rate-limiting requests with 400 errors (not 429s). This seemed especially prevalent on cloud deployed apps behind a VPN, and for trial accounts. Deepgram has been more reliable in my testing.
