### PR TITLE
Add call recording functionality

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,14 @@
+# Optional: Configure your Twilio credentials if you want
+# to make test calls using '$ npm run outbound'.
+TWILIO_ACCOUNT_SID=YOUR-ACCOUNT-SID
+TWILIO_AUTH_TOKEN=YOUR-AUTH-TOKEN
+FROM_NUMBER='+12223334444'
+APP_NUMBER='+13334445555'
+YOUR_NUMBER='+14445556666'
+
 # Your ngrok or server URL
 # E.g. 123.ngrok.io or myserver.fly.dev
-SERVER=
+SERVER='myserver.website.com'
 
 # Service API Keys
 OPENAI_API_KEY=
@@ -9,10 +17,15 @@ DEEPGRAM_API_KEY=
 # Deepgram voice model, see more options here: https://developers.deepgram.com/docs/tts-models
 VOICE_MODEL=aura-asteria-en
 
-# Optional: Configure your Twilio credentials if you want
-# to make test calls using '$ npm run outbound'.
-TWILIO_ACCOUNT_SID=YOUR-ACCOUNT-SID
-TWILIO_AUTH_TOKEN=YOUR-AUTH-TOKEN
-FROM_NUMBER='+12223334444'
-APP_NUMBER='+13334445555'
-YOUR_NUMBER='+14445556666'
+# Call Recording
+# Important: Legal implications of call recording
+
+# If you choose to record voice or video calls, you need to comply with certain laws and regulations,
+# including those regarding obtaining consent to record (such as California's Invasion of Privacy Act
+# and similar laws in other jurisdictions). Additional information on the legal implications of call
+# recording can be found in the "Legal Considerations with Recording Voice and Video Communications"
+# Help Center article: https://help.twilio.com/articles/360011522553-Legal-Considerations-with-Recording-Voice-and-Video-Communications
+
+# Notice: Twilio recommends that you consult with your legal counsel to make sure that you are complying
+# with all applicable laws in connection with communications you record or store using Twilio.
+RECORDING_ENABLED='false'

--- a/services/recording-service.js
+++ b/services/recording-service.js
@@ -1,0 +1,23 @@
+
+require('colors');
+
+async function recordingService(ttsService, callSid) {
+  try {
+    if (process.env.RECORDING_ENABLED === 'true') {
+      const client = require('twilio')(process.env.TWILIO_ACCOUNT_SID, process.env.TWILIO_AUTH_TOKEN);
+      
+      ttsService.generate({partialResponseIndex: null, partialResponse: 'This call will be recorded.'}, 0);
+      const recording = await client.calls(callSid)
+        .recordings
+        .create({
+          recordingChannels: 'dual'
+        });
+          
+      console.log(`Recording Created: ${recording.sid}`.red);
+    }
+  } catch (err) {
+    console.log(err);
+  }
+}
+
+module.exports = { recordingService };


### PR DESCRIPTION
Allows users to record calls by setting `RECORDING_ENABLED='true'` in the `.env` file. Makes use of dual channel recordings compatible with Twilio Voice Intelligence.