### PR TITLE
Fix the issue of Twilio sometimes starting a new websocket connection for the same call concurrently

### DIFF
--- a/app.js
+++ b/app.js
@@ -17,18 +17,70 @@ ExpressWs(app);
 
 const PORT = process.env.PORT || 3000;
 
+async function getCallerNumber(call) {
+  const accountSid = process.env.TWILIO_ACCOUNT_SID;
+  const authToken = process.env.TWILIO_AUTH_TOKEN;
+  const client = require('twilio')(accountSid, authToken);
+
+  const response = await client.calls(call.callSid).fetch();
+  return response.from;
+}
+
 app.post('/incoming', (req, res) => {
   try {
     const response = new VoiceResponse();
     const connect = response.connect();
     connect.stream({ url: `wss://${process.env.SERVER}/connection` });
-  
+
     res.type('text/xml');
     res.end(response.toString());
   } catch (err) {
     console.log(err);
   }
 });
+
+const activeCalls = {};
+
+function bindCall(call) {
+  const { streamSid, gptService, streamService, transcriptionService, ttsService, marks, ws } = call;
+
+  let interactionCount = 0;
+
+  transcriptionService.on('utterance', async (text) => {
+    // This is a bit of a hack to filter out empty utterances
+    if(marks.length > 0 && text?.length > 5) {
+      console.log('Twilio -> Interruption, Clearing stream'.red);
+      ws.send(
+        JSON.stringify({
+          streamSid,
+          event: 'clear',
+        })
+      );
+    }
+  });
+
+  transcriptionService.on('transcription', async (text) => {
+    if (!text) { return; }
+    console.log(`Interaction ${interactionCount} – STT -> GPT: ${text}`.yellow);
+    gptService.completion(text, interactionCount);
+    interactionCount += 1;
+  });
+
+  gptService.on('gptreply', async (gptReply, icount) => {
+    console.log(`Interaction ${icount}: GPT -> TTS: ${gptReply.partialResponse}`.green );
+    ttsService.generate(gptReply, icount);
+  });
+
+  ttsService.on('speech', (responseIndex, audio, label, icount) => {
+    console.log(`Interaction ${icount}: TTS -> TWILIO: ${label}`.blue);
+
+    streamService.buffer(responseIndex, audio);
+  });
+
+  streamService.on('audiosent', (markLabel) => {
+    marks.push(markLabel);
+  });
+}
 
 app.ws('/connection', (ws) => {
   try {
@@ -37,73 +89,65 @@ app.ws('/connection', (ws) => {
     let streamSid;
     let callSid;
 
-    const gptService = new GptService();
-    const streamService = new StreamService(ws);
-    const transcriptionService = new TranscriptionService();
-    const ttsService = new TextToSpeechService({});
-  
-    let marks = [];
-    let interactionCount = 0;
-  
+    let call = null;
+
     // Incoming from MediaStream
     ws.on('message', function message(data) {
       const msg = JSON.parse(data);
       if (msg.event === 'start') {
         streamSid = msg.start.streamSid;
         callSid = msg.start.callSid;
-        
-        streamService.setStreamSid(streamSid);
-        gptService.setCallSid(callSid);
 
-        // Set RECORDING_ENABLED='true' in .env to record calls
-        recordingService(ttsService, callSid).then(() => {
-          console.log(`Twilio -> Starting Media Stream for ${streamSid}`.underline.red);
-          ttsService.generate({partialResponseIndex: null, partialResponse: 'Hello! I understand you\'re looking for a pair of AirPods, is that correct?'}, 0);
+        getCallerNumber(msg.start).then((number) => {
+          if (activeCalls[number]) {
+            return;
+          }
+          console.log(`Twilio -> received new call from ${number}`);
+
+          const transcriptionService = new TranscriptionService();
+
+          call = {
+            callSid: callSid,
+            streamSid: streamSid,
+            gptService: new GptService(),
+            streamService: new StreamService(ws),
+            transcriptionService: transcriptionService,
+            ttsService: new TextToSpeechService({}),
+            marks: [],
+            ws: ws
+          };
+          activeCalls[number] = call;
+          bindCall(call);
+
+          call.streamService.setStreamSid(streamSid);
+          call.gptService.setCallSid(callSid);
+
+          // Set RECORDING_ENABLED='true' in .env to record calls
+          recordingService(call.ttsService, callSid).then(() => {
+            console.log(`Twilio -> Starting Media Stream for ${streamSid}`.underline.red);
+            call.ttsService.generate({partialResponseIndex: null, partialResponse: 'Hello! I understand you\'re looking for a pair of AirPods, is that correct?'}, 0);
+          });
         });
       } else if (msg.event === 'media') {
-        transcriptionService.send(msg.media.payload);
+        if (call && call.transcriptionService != null) {
+          call.transcriptionService.send(msg.media.payload);
+        }
       } else if (msg.event === 'mark') {
         const label = msg.mark.name;
         console.log(`Twilio -> Audio completed mark (${msg.sequenceNumber}): ${label}`.red);
-        marks = marks.filter(m => m !== msg.mark.name);
+        if (call && call.marks) {
+          call.marks = call.marks.filter(m => m !== msg.mark.name);
+        }
       } else if (msg.event === 'stop') {
         console.log(`Twilio -> Media stream ${streamSid} ended.`.underline.red);
+
+        for (const k in Object.keys(activeCalls)) {
+          if (activeCalls[k] == callSid){
+            delete activeCalls[k];
+            return;
+          }
+        }
       }
-    });
-  
-    transcriptionService.on('utterance', async (text) => {
-      // This is a bit of a hack to filter out empty utterances
-      if(marks.length > 0 && text?.length > 5) {
-        console.log('Twilio -> Interruption, Clearing stream'.red);
-        ws.send(
-          JSON.stringify({
-            streamSid,
-            event: 'clear',
-          })
-        );
-      }
-    });
-  
-    transcriptionService.on('transcription', async (text) => {
-      if (!text) { return; }
-      console.log(`Interaction ${interactionCount} – STT -> GPT: ${text}`.yellow);
-      gptService.completion(text, interactionCount);
-      interactionCount += 1;
-    });
-    
-    gptService.on('gptreply', async (gptReply, icount) => {
-      console.log(`Interaction ${icount}: GPT -> TTS: ${gptReply.partialResponse}`.green );
-      ttsService.generate(gptReply, icount);
-    });
-  
-    ttsService.on('speech', (responseIndex, audio, label, icount) => {
-      console.log(`Interaction ${icount}: TTS -> TWILIO: ${label}`.blue);
-  
-      streamService.buffer(responseIndex, audio);
-    });
-  
-    streamService.on('audiosent', (markLabel) => {
-      marks.push(markLabel);
     });
   } catch (err) {
     console.log(err);

--- a/app.js
+++ b/app.js
@@ -142,7 +142,7 @@ app.ws('/connection', (ws) => {
         console.log(`Twilio -> Media stream ${streamSid} ended.`.underline.red);
 
         for (const k in Object.keys(activeCalls)) {
-          if (activeCalls[k] == callSid){
+          if (activeCalls[k] && activeCalls[k].callSid == callSid) {
             delete activeCalls[k];
             return;
           }


### PR DESCRIPTION
I noticed in testing that Twilio sometimes re-invokes a websocket connection during the call which was resulting in duplicated streams running and me hearing multiple confused TTS voices at different stages of my call flow. By refusing to initiate more than one call per unique calling phone number, this problem was completely eliminated for me.

If it helps, I was calling from a cellphone with wifi-based calling enabled so I considered it's possible that when a cellphone switches from wifi-calling back to the 4G network that Twilio thinks the stream was interrupted and tries to open a new webosocket.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
